### PR TITLE
[TSK-276] Date Controls in Telegram Scraper

### DIFF
--- a/app/scraper.py
+++ b/app/scraper.py
@@ -123,12 +123,14 @@ async def scrape(
         except ValueError as e:
             format_check = f"does not match format '{date_format}'"
             if format_check in str(e):
-                human_date_format = date_format.replace("%Y", "YYYY") \
-                    .replace("%m", "mm") \
-                    .replace("%d", "dd") \
-                    .replace("%H", "HH") \
-                    .replace("%M", "MM") \
+                human_date_format = (
+                    date_format.replace("%Y", "YYYY")
+                    .replace("%m", "mm")
+                    .replace("%d", "dd")
+                    .replace("%H", "HH")
+                    .replace("%M", "MM")
                     .replace("%S", "SS")
+                )
                 raise ValueError(
                     f"Start and end dates must be in {human_date_format} format"
                 )
@@ -156,8 +158,7 @@ async def scrape(
 
             try:
                 async for message in client.iter_messages(
-                    f"https://t.me/{channel_name}",
-                    offset_date=end_datetime
+                    f"https://t.me/{channel_name}", offset_date=end_datetime
                 ):
                     ############################################################
                     # IF YOU CAN ALREADY VALIDATE YOUR DATA HERE
@@ -205,7 +206,8 @@ async def scrape(
                                 )
 
                                 file_name = f"{os.path.basename(tmp.name)}"
-                                relative_path = f"telegram/{tracer_id}/{job_id}/photos/{channel_name}-{file_name}.photo"
+                                file_timestamp = message.date.timestamp()
+                                relative_path = f"telegram/{tracer_id}/{job_id}/photos/{message.from_id}-{file_timestamp}.photo"
 
                                 data_name = os.path.splitext(file_name)[0]
 
@@ -245,7 +247,8 @@ async def scrape(
                                 )
 
                                 file_name = f"{os.path.basename(tmp.name)}"
-                                relative_path = f"telegram/{tracer_id}/{job_id}/videos/{channel_name}-{file_name}.video"
+                                file_timestamp = message.date.timestamp()
+                                relative_path = f"telegram/{tracer_id}/{job_id}/videos/{message.from_id}-{file_timestamp}.video"
                                 data_name = os.path.splitext(file_name)[0]
 
                                 document_data = KernelPlancksterSourceData(

--- a/telegram_scraper.py
+++ b/telegram_scraper.py
@@ -12,6 +12,8 @@ def main(
     job_id: int,
     channel_name: str,
     tracer_id: str,
+    start_date: str,
+    end_date: str,
     kp_auth_token: str,
     kp_host: str,
     kp_port: int,
@@ -28,9 +30,10 @@ def main(
     logger = logging.getLogger(__name__)
     logging.basicConfig(level=log_level)
 
-    if not all([job_id, channel_name, tracer_id]):
-        logger.error(f"{job_id}: job_id, tracer_id, and channel_name must all be set.")
-        raise ValueError("job_id, tracer_id, and channel_name must all be set.")
+    if not all([job_id, channel_name, tracer_id, start_date, end_date]):
+        error_msg = "job_id, tracer_id, channel_name, and date range must all be set"
+        logger.error(f"{job_id}: {error_msg}")
+        raise ValueError(error_msg)
 
     kernel_planckster, protocol, file_repository = setup(
         job_id=job_id,
@@ -66,6 +69,8 @@ def main(
             job_id=job_id,
             channel_name=channel_name,
             tracer_id=tracer_id,
+            start_date=start_date,
+            end_date=end_date,
             scraped_data_repository=scraped_data_repository,
             telegram_client=telegram_client,
             log_level=log_level,
@@ -101,6 +106,20 @@ if __name__ == "__main__":
         type=str,
         default="1",
         help="The tracer id",
+    )
+
+    parser.add_argument(
+        "--start_date",
+        type=str,
+        default="2024-06-01",
+        help="The earliest date(time) from which to scrape, in YYYY-MM-DD format",
+    )
+
+    parser.add_argument(
+        "--end_date",
+        type=str,
+        default="2024-06-10",
+        help="The latest date(time) from which to scrape, in YYYY-MM-DD format",
     )
 
     parser.add_argument(
@@ -186,6 +205,8 @@ if __name__ == "__main__":
         job_id=args.job_id,
         channel_name=args.channel_name,
         tracer_id=args.tracer_id,
+        start_date=args.start_date,
+        end_date=args.end_date,
         log_level=args.log_level,
         kp_auth_token=args.kp_auth_token,
         kp_host=args.kp_host,

--- a/telegram_scraper.py
+++ b/telegram_scraper.py
@@ -109,17 +109,17 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "--start_date",
+        "--start-date",
         type=str,
         default="2024-06-01",
-        help="The earliest date(time) from which to scrape, in YYYY-MM-DD format",
+        help="The earliest date(time) from which to scrape, in YYYY-MM-DD HH:MM:SS format",
     )
 
     parser.add_argument(
-        "--end_date",
+        "--end-date",
         type=str,
         default="2024-06-10",
-        help="The latest date(time) from which to scrape, in YYYY-MM-DD format",
+        help="The latest date(time) from which to scrape, in YYYY-MM-DD HH:MM:SS format",
     )
 
     parser.add_argument(


### PR DESCRIPTION
Introduces start and end date arguments, and includes them in the scraping logic for Telegram.

Unlike the other tools currently in use, Telegram's `telethon` package requires that dates be provided in datetime format. It offers the `offset_date` for end date, but has no equivalent for start date. As a result, start/minimum date functionality is achieved by filtering the returned messages by their date property (which is also in datetime format).

Since the arguments can only be provided as strings, a format of YYYY-MM-DD is assumed, and validated for.